### PR TITLE
Config and deployment changes for multi-cluster support

### DIFF
--- a/services/app-exposer/k8s/app-exposer.yml
+++ b/services/app-exposer/k8s/app-exposer.yml
@@ -61,6 +61,11 @@ spec:
             - "$(VICE_LOCAL_STORAGE_CLASS)"
             - --log-level
             - debug
+            - --enable-legacy-vice-proxy-auth
+            - --check-resource-access-service
+            - http://check-resource-access
+            - --cluster-config-secret
+            - "$(CLUSTER_CONFIG_SECRET)"
           env:
             - name: TZ
               valueFrom:
@@ -98,6 +103,11 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: VICE_LOCAL_STORAGE_CLASS
+            - name: CLUSTER_CONFIG_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: CLUSTER_CONFIG_SECRET
           ports:
             - name: listen-port
               containerPort: 60000

--- a/services/app-exposer/k8s/app-exposer.yml
+++ b/services/app-exposer/k8s/app-exposer.yml
@@ -59,11 +59,6 @@ spec:
             - "$(VICE_LOCAL_STORAGE_CLASS)"
             - --log-level
             - debug
-            - --enable-legacy-vice-proxy-auth
-            - --check-resource-access-service
-            - http://check-resource-access
-            - --cluster-config-secret
-            - "$(CLUSTER_CONFIG_SECRET)"
           env:
             - name: TZ
               valueFrom:
@@ -101,11 +96,6 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: VICE_LOCAL_STORAGE_CLASS
-            - name: CLUSTER_CONFIG_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: configs
-                  key: CLUSTER_CONFIG_SECRET
           ports:
             - name: listen-port
               containerPort: 60000

--- a/services/maintenance-page/k8s/maintenance-page.yaml
+++ b/services/maintenance-page/k8s/maintenance-page.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maintenance-page
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maintenance-page
+  template:
+    metadata:
+      labels:
+        app: maintenance-page
+    spec:
+      serviceAccountName: maintenance-page
+      containers:
+        - name: maintenance-page
+          image: harbor.cyverse.org/de/maintenance-page
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "128Mi"
+              ephemeral-storage: "100Mi"
+            limits:
+              cpu: "100m"
+              memory: "256Mi"
+              ephemeral-storage: "100Mi"
+          args:
+            - --namespace=$(DE_ENV)
+          env:
+            - name: DE_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: DE_ENV
+            - name: BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: BASIC_AUTH_USERNAME
+            - name: BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: BASIC_AUTH_PASSWORD
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: admin
+              containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 2

--- a/services/maintenance-page/skaffold.yaml
+++ b/services/maintenance-page/skaffold.yaml
@@ -12,6 +12,6 @@ build:
   local: {}
 manifests:
   rawYaml:
-    - k8s/maintenance-page.yml
+    - k8s/maintenance-page.yaml
 deploy:
   kubectl: {}

--- a/services/vice-default-backend/k8s/vice-default-backend.yml
+++ b/services/vice-default-backend/k8s/vice-default-backend.yml
@@ -43,9 +43,6 @@ spec:
               cpu: "100m"
               memory: "256Mi"
               ephemeral-storage: "1Gi"
-          args:
-            - --config
-            - /etc/iplant/de/jobservices.yml
           env:
             - name: TZ
               valueFrom:

--- a/templates/jobservices.yml.j2
+++ b/templates/jobservices.yml.j2
@@ -96,16 +96,13 @@ users:
   domain: "{{ uid_domain }}"
 
 vice:
+  keycloak:
+    base_url: "{{ vice_operator_keycloak_base_url }}"
+    realm: "{{ vice_operator_keycloak_realm }}"
+    client_id: "{{ vice_operator_keycloak_client_id }}"
+    client_secret: "{{ vice_operator_keycloak_client_secret }}"
   db:
     uri: "postgresql://{{ dbms_connection_user }}:{{ dbms_connection_pass | urlencode }}@{{ groups['dbms'][0] }}:{{ pg_listen_port }}/{{ de_db_name }}?sslmode=disable"
-  operators:
-{% for vice_operator in vice_operators_values %}
-    - name: {{ vice_operator.name }}
-      url: {{ vice_operator.url }}
-      insecure: {{ vice_operator.insecure }}
-      username: {{ vice_operator.username }}
-      password: {{ vice_operator.password }}
-{% endfor %}
   file-transfers:
     image: "{{ vice_file_transfers_image }}"
     tag: "{{ vice_file_transfers_tag }}"

--- a/templates/jobservices.yml.j2
+++ b/templates/jobservices.yml.j2
@@ -98,6 +98,14 @@ users:
 vice:
   db:
     uri: "postgresql://{{ dbms_connection_user }}:{{ dbms_connection_pass | urlencode }}@{{ groups['dbms'][0] }}:{{ pg_listen_port }}/{{ de_db_name }}?sslmode=disable"
+  operators:
+{% for vice_operator in vice_operators_values %}
+    - name: {{ vice_operator.name }}
+      url: {{ vice_operator.url }}
+      insecure: {{ vice_operator.insecure }}
+      username: {{ vice_operator.username }}
+      password: {{ vice_operator.password }}
+{% endfor %}
   file-transfers:
     image: "{{ vice_file_transfers_image }}"
     tag: "{{ vice_file_transfers_tag }}"


### PR DESCRIPTION
Changes the vice-default-backend deployment to work with the new waiting page version of the service.
Updates jobservices.yml.j2 template to support keycloak configuration for VICE.
Remove basic auth flags for the maintenance page. Reads from environment now.