### PR TITLE
CORE-2158: settings for the Authorization Code flow

### DIFF
--- a/builds/async-tasks.json
+++ b/builds/async-tasks.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"harbor.cyverse.org/de/async-tasks","tag":"harbor.cyverse.org/de/async-tasks:v2026.06.02@sha256:6bdf4e7f769600c302f07328310d80d949374b1eabe11a9e6b028bfa1b33b114"}]}
+{"builds":[{"imageName":"harbor.cyverse.org/de/async-tasks","tag":"harbor.cyverse.org/de/async-tasks:v2026.07.07-rc01@sha256:5f829eb88e8cf4cee21a58c78c2219bd7e414a7ce033e23c989e213d26a9b90e"}]}

--- a/templates/terrain.properties.j2
+++ b/templates/terrain.properties.j2
@@ -1,6 +1,9 @@
 # Connection details.
 terrain.app.listen-port = 60000
 
+# The user-accessible base URL.
+terrain.base-uri = {{ de_base_uri }}/terrain
+
 # Environment information.
 terrain.app.environment-name = {{ ns }}
 
@@ -119,6 +122,7 @@ terrain.keycloak.base-uri = {{ keycloak_server_uri }}
 terrain.keycloak.realm = {{ keycloak_realm_name }}
 terrain.keycloak.client-id = {{ keycloak_client_id }}
 terrain.keycloak.client-secret = {{ keycloak_client_secret }}
+terrain.keycloak.secure-cookies = true
 
 # Keycloak Admin API settings
 terrain.keycloak.admin-base-uri = {{ keycloak_admin_server_uri }}


### PR DESCRIPTION
These changes are pretty straightforward. The base URI for Terrain is derived from the `de_base_uri` group var. The `secure-cookies` setting is always `true` since the only time we'd want to set it to `false` is for local development testing anyway.